### PR TITLE
Add CamelCaseNamingStrategy to FuzzyObjectContractResolverSettings

### DIFF
--- a/PageUp.FuzzySerializer.Tests/FuzzyObjectContractResolverSettingsTests.cs
+++ b/PageUp.FuzzySerializer.Tests/FuzzyObjectContractResolverSettingsTests.cs
@@ -23,5 +23,12 @@ namespace PageUp.FuzzySerializer.Tests
             var settings = new FuzzyObjectContractResolverSettings();
             Assert.Equal(true, settings.AddPropertyInRandomPosition);
         }
+
+        [Fact]
+        public void DefaultSettings_Initiated_UseCamelCaseNamingStrategyIsOff()
+        {
+            var settings = new FuzzyObjectContractResolverSettings();
+            Assert.Equal(false, settings.UseCamelCaseNamingStrategy);
+        }
     }
 }

--- a/PageUp.FuzzySerializer.Tests/FuzzyObjectContractResolverTests.cs
+++ b/PageUp.FuzzySerializer.Tests/FuzzyObjectContractResolverTests.cs
@@ -175,6 +175,42 @@ namespace PageUp.FuzzySerializer.Tests
             }
         }
 
+        [Fact]
+        public void UseCamelCaseNamingStrategyIsOn_Serialize_AllPropertyNamesFollowCamelCaseNamingStrategy()
+        {
+            var jsonSerializeSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new FuzzyObjectContractResolver(new FuzzyObjectContractResolverSettings { UseCamelCaseNamingStrategy = true, AddRandomPropertyToObjects = false })
+            };
+
+            var serialisedObject = JsonConvert.SerializeObject(
+                _person, Formatting.None, jsonSerializeSettings);
+
+            var deserialisedObj = (JObject)JsonConvert.DeserializeObject(serialisedObject);
+            
+            Assert.Equal(2, deserialisedObj.Count);
+            Assert.Equal("Abhaya Chauhan", deserialisedObj["name"]);
+            Assert.Equal("21", deserialisedObj["age"]);
+        }
+
+        [Fact]
+        public void UseCamelCaseNamingStrategyIsOff_Serialize_AllPropertyNamesRemainUnchanged()
+        {
+            var jsonSerializeSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new FuzzyObjectContractResolver(new FuzzyObjectContractResolverSettings { UseCamelCaseNamingStrategy = false, AddRandomPropertyToObjects = false })
+            };
+
+            var serialisedObject = JsonConvert.SerializeObject(
+                _person, Formatting.None, jsonSerializeSettings);
+
+            var deserialisedObj = (JObject)JsonConvert.DeserializeObject(serialisedObject);
+
+            Assert.Equal(2, deserialisedObj.Count);
+            Assert.Equal("Abhaya Chauhan", deserialisedObj["Name"]);
+            Assert.Equal("21", deserialisedObj["Age"]);
+        }
+
         private int FindIndexOfPropertyKey(JObject deserialisedPerson, string propertyName) {
             int index = 0;
             foreach (var keyValuePair in deserialisedPerson) 

--- a/PageUp.FuzzySerializer/FuzzyObjectContractResolver.cs
+++ b/PageUp.FuzzySerializer/FuzzyObjectContractResolver.cs
@@ -16,6 +16,15 @@ namespace PageUp.FuzzySerializer {
         public FuzzyObjectContractResolver(FuzzyObjectContractResolverSettings settings)
         {
             _settings = settings;
+
+            if (settings.UseCamelCaseNamingStrategy)
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    ProcessDictionaryKeys = true,
+                    OverrideSpecifiedNames = true
+                };
+            }
         }
 
         public override JsonContract ResolveContract(Type type) {

--- a/PageUp.FuzzySerializer/FuzzyObjectContractResolverSettings.cs
+++ b/PageUp.FuzzySerializer/FuzzyObjectContractResolverSettings.cs
@@ -4,5 +4,6 @@ namespace PageUp.FuzzySerializer {
         public bool ShuffleResponse = true;
         public bool AddRandomPropertyToObjects = true;
         public bool AddPropertyInRandomPosition = true;
+        public bool UseCamelCaseNamingStrategy = false;
     }
 }


### PR DESCRIPTION
* Add UseCamelCaseNamingStrategy setting to FuzzyObjectContractResolverSettings which makes all property names follow the camel case naming convention

* The setting is turned off by default